### PR TITLE
Simplifications to program logic

### DIFF
--- a/filemapping.example.json
+++ b/filemapping.example.json
@@ -1,44 +1,13 @@
 {
-  "mappings": [
-    {
-      "path": "/example.txt",
-      "target": "/real/target/example.txt",
-      "permissions": {
-        "owner": 1000,
-        "group": 1000,
-        "mode": 420
-      }
-    },
-    {
-      "path": "/restricted-folder",
-      "target": "/real/target/restricted-folder",
-      "permissions": {
-        "owner": 1000,
-        "group": 1000,
-        "mode": 448
-      }
-    },
-    {
-      "path": "/readonly.txt",
-      "target": "/real/target/readonly.txt",
-      "permissions": {
-        "owner": 1000,
-        "group": 1000,
-        "mode": 292
-      }
-    },
-    {
-      "path": "/same-permissions-file.txt",
-      "target": "/real/target/same-permissions-file.txt"
-    },
-    {
-      "path": "/another-example.txt",
-      "target": "/real/target/another-example.txt",
-      "permissions": {
-        "owner": 2000,
-        "group": 2000,
-        "mode": 332
-      }
-    }
-  ]
+  "/example.txt": {
+    "path": "/example.txt",
+    "target": "/underlying_fs/real_example.txt"
+  },
+  "/example2.txt": {
+    "path": "/example2.txt"
+  },
+  "/some/dir": {
+    "path": "/some/dir",
+    "target": "/underlying_fs/some/dir"
+  }
 }


### PR DESCRIPTION
Simplifications to logic:

* Removed permission overriding, this would be very tricky to implement and would be of minimal use
* Changed the interpretation of the json payload to allow for 'removal' of a path that continues to exist at the target directory.
* Changed the interpretation of the json payload to treat relative paths in the target field of the mapping as relative to the mounted target point. 
* Tests for the new features.